### PR TITLE
fixed Rectangle::setHeight()

### DIFF
--- a/src/TSGL/Rectangle.cpp
+++ b/src/TSGL/Rectangle.cpp
@@ -112,7 +112,7 @@ void Rectangle::setHeight(GLfloat height) {
         return;
     }
     attribMutex.lock();
-    myWidth = height;
+    myHeight = height;
     myYScale = height;
     attribMutex.unlock();
 }


### PR DESCRIPTION
setHeight() updated the width instead of the height of the rectangle...

discovered this bug while debugging with getHeight(), which produced improper results